### PR TITLE
task1.2

### DIFF
--- a/1_concepts/1_2_box_pin/src/main.rs
+++ b/1_concepts/1_2_box_pin/src/main.rs
@@ -5,26 +5,35 @@ fn main() {
     SayHi::say_hi(Pin::new(&&arr[..]));
 }
 
-// `Box<T>`, `Rc<T>`, `Vec<T>`, `String`, `&[u8]`, `T`.  
+// `Box<T>`, `Rc<T>`, `Vec<T>`, `String`, `&[u8]`, `T`.
 trait SayHi: fmt::Debug {
     fn say_hi(self: Pin<&Self>) {
         println!("Hi from {:?}", self)
     }
 }
 
-impl<T> SayHi for Box<T> where T: fmt::Debug {
+impl<T> SayHi for Box<T>
+where
+    T: fmt::Debug,
+{
     fn say_hi(self: Pin<&Self>) {
         println!("Hi from {:?}", self)
     }
 }
 
-impl<T> SayHi for Rc<T> where T: fmt::Debug {
+impl<T> SayHi for Rc<T>
+where
+    T: fmt::Debug,
+{
     fn say_hi(self: Pin<&Self>) {
         println!("Hi from {:?}", self)
     }
 }
 
-impl<T> SayHi for Vec<T> where T: fmt::Debug {
+impl<T> SayHi for Vec<T>
+where
+    T: fmt::Debug,
+{
     fn say_hi(self: Pin<&Self>) {
         println!("Hi from {:?}", self)
     }
@@ -55,7 +64,7 @@ trait MutMeSomehow {
     /// obviously call something requiring `&mut self`.
     /// The point here is to practice dealing with
     /// `Pin<&mut Self>` -> `&mut self` conversion
-    /// in different contexts, without introducing 
+    /// in different contexts, without introducing
     /// any `Unpin` trait bounds.
     fn mut_me_somehow(self: Pin<&mut Self>);
 }
@@ -63,20 +72,19 @@ trait MutMeSomehow {
 /// shoot in leg
 /// DO NOT USE EVER
 fn get_a_menaingful_T<T>() -> T {
-    unsafe { std::mem::zeroed()}
+    unsafe { std::mem::zeroed() }
 }
 
 /// Same thing
 
 // impl<T> MutMeSomehow for T {
 //     fn mut_me_somehow(mut self: Pin<&mut Self>) {
-        
+
 //         self.set(get_a_menaingful_T)
 //     }
 // }
 
-impl<T> MutMeSomehow for Box<T>  {
-
+impl<T> MutMeSomehow for Box<T> {
     fn mut_me_somehow(mut self: Pin<&mut Self>) {
         self.set(get_a_menaingful_T())
     }
@@ -103,10 +111,9 @@ impl MutMeSomehow for String {
 
 impl MutMeSomehow for &[u8] {
     fn mut_me_somehow(mut self: Pin<&mut Self>) {
-        self.set(&self[1..]) //cut the leftmost slice element 
+        self.set(&self[1..]) //cut the leftmost slice element
     }
 }
-
 
 //###################################################
 
@@ -116,32 +123,38 @@ struct MeasurableFuture<Fut> {
 }
 
 impl<F> MeasurableFuture<F> {
-    fn project<'s>(self: Pin<&'s mut Self>) -> (Pin<&'s mut F>,&'s mut Option<std::time::Instant>) {
-        
+    fn project<'s>(
+        self: Pin<&'s mut Self>,
+    ) -> (Pin<&'s mut F>, &'s mut Option<std::time::Instant>) {
         // Safety: we don't move anything here
         let this = unsafe { self.get_unchecked_mut() };
-        
+
         // safety: and here also
-        let inner = unsafe { Pin::new_unchecked(&mut this.inner_future)};
+        let inner = unsafe { Pin::new_unchecked(&mut this.inner_future) };
         let time_ = &mut this.started_at;
 
         //no intersection between pointers, and pin is preserved
-        (inner,time_)
+        (inner, time_)
     }
 }
 
-impl<Fut> Future for MeasurableFuture<Fut> where Fut: Future {
+impl<Fut> Future for MeasurableFuture<Fut>
+where
+    Fut: Future,
+{
     type Output = Fut::Output;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
+    fn poll(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let (inner, started_at) = self.project();
 
-        let (inner,started_at) = self.project();
-
-        match Future::poll(inner,cx) {
+        match Future::poll(inner, cx) {
             std::task::Poll::Ready(out) => {
-                println!("time elapsed: {:?}",started_at.unwrap().elapsed());
+                println!("time elapsed: {:?}", started_at.unwrap().elapsed());
                 std::task::Poll::Ready(out)
-            },
+            }
             std::task::Poll::Pending => std::task::Poll::Pending,
         }
     }

--- a/1_concepts/1_2_box_pin/src/main.rs
+++ b/1_concepts/1_2_box_pin/src/main.rs
@@ -1,3 +1,148 @@
+use std::{fmt, future::Future, pin::Pin, rc::Rc};
+
 fn main() {
-    println!("Implement me!");
+    let arr = [255u8];
+    SayHi::say_hi(Pin::new(&&arr[..]));
+}
+
+// `Box<T>`, `Rc<T>`, `Vec<T>`, `String`, `&[u8]`, `T`.  
+trait SayHi: fmt::Debug {
+    fn say_hi(self: Pin<&Self>) {
+        println!("Hi from {:?}", self)
+    }
+}
+
+impl<T> SayHi for Box<T> where T: fmt::Debug {
+    fn say_hi(self: Pin<&Self>) {
+        println!("Hi from {:?}", self)
+    }
+}
+
+impl<T> SayHi for Rc<T> where T: fmt::Debug {
+    fn say_hi(self: Pin<&Self>) {
+        println!("Hi from {:?}", self)
+    }
+}
+
+impl<T> SayHi for Vec<T> where T: fmt::Debug {
+    fn say_hi(self: Pin<&Self>) {
+        println!("Hi from {:?}", self)
+    }
+}
+
+impl SayHi for String {
+    fn say_hi(self: Pin<&Self>) {
+        println!("Hi from {:?}", self)
+    }
+}
+
+impl SayHi for &[u8] {
+    fn say_hi(self: Pin<&Self>) {
+        println!("Hi from {:?}", self)
+    }
+}
+
+/// COmmented out so it doesn't mess with specialization
+
+// impl<T> SayHi for T where T: fmt::Debug {
+//     fn say_hi(self: Pin<&Self>) {
+//         println!("Hi from {:?}", self)
+//     }
+// }
+
+trait MutMeSomehow {
+    /// Implementation must be meaningful, and
+    /// obviously call something requiring `&mut self`.
+    /// The point here is to practice dealing with
+    /// `Pin<&mut Self>` -> `&mut self` conversion
+    /// in different contexts, without introducing 
+    /// any `Unpin` trait bounds.
+    fn mut_me_somehow(self: Pin<&mut Self>);
+}
+
+/// shoot in leg
+/// DO NOT USE EVER
+fn get_a_menaingful_T<T>() -> T {
+    unsafe { std::mem::zeroed()}
+}
+
+/// Same thing
+
+// impl<T> MutMeSomehow for T {
+//     fn mut_me_somehow(mut self: Pin<&mut Self>) {
+        
+//         self.set(get_a_menaingful_T)
+//     }
+// }
+
+impl<T> MutMeSomehow for Box<T>  {
+
+    fn mut_me_somehow(mut self: Pin<&mut Self>) {
+        self.set(get_a_menaingful_T())
+    }
+}
+
+impl<T> MutMeSomehow for Rc<T> {
+    fn mut_me_somehow(self: Pin<&mut Self>) {
+        unimplemented!("It's hardly possible to mutate a refcounted value in a sane way");
+    }
+}
+
+impl<T> MutMeSomehow for Vec<T> {
+    fn mut_me_somehow(mut self: Pin<&mut Self>) {
+        self.set(vec![get_a_menaingful_T()]);
+    }
+}
+
+impl MutMeSomehow for String {
+    fn mut_me_somehow(mut self: Pin<&mut Self>) {
+        let lc = self.to_ascii_lowercase(); // mb could have done that in place
+        self.set(lc);
+    }
+}
+
+impl MutMeSomehow for &[u8] {
+    fn mut_me_somehow(mut self: Pin<&mut Self>) {
+        self.set(&self[1..]) //cut the leftmost slice element 
+    }
+}
+
+
+//###################################################
+
+struct MeasurableFuture<Fut> {
+    inner_future: Fut,
+    started_at: Option<std::time::Instant>,
+}
+
+impl<F> MeasurableFuture<F> {
+    fn project<'s>(self: Pin<&'s mut Self>) -> (Pin<&'s mut F>,&'s mut Option<std::time::Instant>) {
+        
+        // Safety: we don't move anything here
+        let this = unsafe { self.get_unchecked_mut() };
+        
+        // safety: and here also
+        let inner = unsafe { Pin::new_unchecked(&mut this.inner_future)};
+        let time_ = &mut this.started_at;
+
+        //no intersection between pointers, and pin is preserved
+        (inner,time_)
+    }
+}
+
+impl<Fut> Future for MeasurableFuture<Fut> where Fut: Future {
+    type Output = Fut::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
+
+        let (inner,started_at) = self.project();
+
+        match Future::poll(inner,cx) {
+            std::task::Poll::Ready(out) => {
+                println!("time elapsed: {:?}",started_at.unwrap().elapsed());
+                std::task::Poll::Ready(out)
+            },
+            std::task::Poll::Pending => std::task::Poll::Pending,
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Each step must be performed as a separate [PR (pull request)][PR] with an approp
 - [ ] [0. Become familiar with Rust basics][Step 0] (3 days)
 - [ ] [1. Concepts][Step 1] (2 days, after all sub-steps)
     - [ ] [1.1. Default values, cloning and copying][Step 1.1] (1 day)
-    - [ ] [1.2. Boxing and pinning][Step 1.2] (1 day)
+    - [x] [1.2. Boxing and pinning][Step 1.2] (1 day)
     - [ ] [1.3. Shared ownership and interior mutability][Step 1.3] (1 day)
     - [ ] [1.4. Clone-on-write][Step 1.4] (1 day)
     - [ ] [1.5. Conversions, casting and dereferencing][Step 1.5] (1 day)


### PR DESCRIPTION
<!-- To use "Bugfix" PR template add `&template=Bugfix.md` to this page's URL. -->

<!-- To use "Roadmap" PR template add `&template=Roadmap.md` to this page's URL. -->

<!-- To use "Task" PR template add `&template=Task.md` to this page's URL. -->

<!-- Remove everything above before submitting this PR. -->


<!-- Name this PR as: "Step <step-number>: <step-name>". -->





## Task

1. For the following types: `Box<T>`, `Rc<T>`, `Vec<T>`, `String`, `&[u8]`, `T`.  
   Implement the following traits:
   ```rust
   trait SayHi: fmt::Debug {
       fn say_hi(self: Pin<&Self>) {
           println!("Hi from {:?}", self)
       }
   }
   ```
   ```rust
   trait MutMeSomehow {
       fn mut_me_somehow(self: Pin<&mut Self>) {
           // Implementation must be meaningful, and
           // obviously call something requiring `&mut self`.
           // The point here is to practice dealing with
           // `Pin<&mut Self>` -> `&mut self` conversion
           // in different contexts, without introducing 
           // any `Unpin` trait bounds.
       }
   }
   ```

2. For the following structure:
   ```rust
   struct MeasurableFuture<Fut> {
       inner_future: Fut,
       started_at: Option<std::time::Instant>,
   }
   ```
   Provide a [`Future`] trait implementation, transparently polling the `inner_future`, and printing its execution time in nanoseconds once it's ready. Using `Fut: Unpin` trait bound (or similar) is not allowed. 





## Solution

hope i made projection right; and there are few commented impls due to specialization
