### PR TITLE
task 1.4

### DIFF
--- a/1_concepts/1_4_cow/src/main.rs
+++ b/1_concepts/1_4_cow/src/main.rs
@@ -2,12 +2,12 @@ use std::borrow::Cow;
 
 const DEFAULT_CONF_PATH: &'static str = "/etc/app/app.conf";
 
-fn main() -> Result<(),&'static str> {
+fn main() -> Result<(), &'static str> {
     let mut args = std::env::args();
     let argc: usize = args.len();
 
     let no_args_case = || {
-        if let Ok(env) = std::env::var("APP_CONF")  {
+        if let Ok(env) = std::env::var("APP_CONF") {
             if env != "" {
                 return Ok(Cow::<str>::Owned(env));
             };
@@ -17,21 +17,21 @@ fn main() -> Result<(),&'static str> {
         }
     };
 
-    let mut window = [args.next(),args.next()];
+    let mut window = [args.next(), args.next()];
     let mut args_case = || {
         loop {
             match window {
-                [Some(ref f),Some(ref v)] => {
-                    match [f.as_str(),v.as_str()] {
-                        ["--conf",path] => {
+                [Some(ref f), Some(ref v)] => {
+                    match [f.as_str(), v.as_str()] {
+                        ["--conf", path] => {
                             if path != "" {
-                                return Ok(Cow::Owned(path.into())) // in theory we can avoid even this one, but rust =(
+                                return Ok(Cow::Owned(path.into())); // in theory we can avoid even this one, but rust =(
                             };
-                            return Err("Err: empty conf argument")
-                        },
+                            return Err("Err: empty conf argument");
+                        }
                         _ => {
                             let [ref mut fst, ref mut snd] = &mut window;
-                            std::mem::swap(fst,snd);
+                            std::mem::swap(fst, snd);
                             *snd = args.next();
                         }
                     }
@@ -40,7 +40,7 @@ fn main() -> Result<(),&'static str> {
                 [None, Some(_)] => unreachable!("args iter broken...."),
                 [Some(_), None] => break,
             }
-        };
+        }
         no_args_case()
     };
 

--- a/1_concepts/1_4_cow/src/main.rs
+++ b/1_concepts/1_4_cow/src/main.rs
@@ -1,3 +1,55 @@
-fn main() {
-    println!("Implement me!");
+use std::borrow::Cow;
+
+const DEFAULT_CONF_PATH: &'static str = "/etc/app/app.conf";
+
+fn main() -> Result<(),&'static str> {
+    let mut args = std::env::args();
+    let argc: usize = args.len();
+
+    let no_args_case = || {
+        if let Ok(env) = std::env::var("APP_CONF")  {
+            if env != "" {
+                return Ok(Cow::<str>::Owned(env));
+            };
+            Err("APP_CONF value is empty")
+        } else {
+            Ok(Cow::<str>::Borrowed(DEFAULT_CONF_PATH))
+        }
+    };
+
+    let mut window = [args.next(),args.next()];
+    let mut args_case = || {
+        loop {
+            match window {
+                [Some(ref f),Some(ref v)] => {
+                    match [f.as_str(),v.as_str()] {
+                        ["--conf",path] => {
+                            if path != "" {
+                                return Ok(Cow::Owned(path.into())) // in theory we can avoid even this one, but rust =(
+                            };
+                            return Err("Err: empty conf argument")
+                        },
+                        _ => {
+                            let [ref mut fst, ref mut snd] = &mut window;
+                            std::mem::swap(fst,snd);
+                            *snd = args.next();
+                        }
+                    }
+                }
+                [None, None] => break,
+                [None, Some(_)] => unreachable!("args iter broken...."),
+                [Some(_), None] => break,
+            }
+        };
+        no_args_case()
+    };
+
+    let path: Cow<'_, str> = if argc < 2 {
+        no_args_case()?
+    } else {
+        args_case()?
+    };
+
+    println!("THE path chosen: {path}");
+    Ok(())
 }

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Each step must be performed as a separate [PR (pull request)][PR] with an approp
     - [ ] [1.1. Default values, cloning and copying][Step 1.1] (1 day)
     - [ ] [1.2. Boxing and pinning][Step 1.2] (1 day)
     - [ ] [1.3. Shared ownership and interior mutability][Step 1.3] (1 day)
-    - [ ] [1.4. Clone-on-write][Step 1.4] (1 day)
+    - [x] [1.4. Clone-on-write][Step 1.4] (1 day)
     - [ ] [1.5. Conversions, casting and dereferencing][Step 1.5] (1 day)
     - [ ] [1.6. Static and dynamic dispatch][Step 1.6] (1 day)
     - [ ] [1.7. `Sized` and `?Sized` types][Step 1.7] (1 day)


### PR DESCRIPTION
<!-- To use "Bugfix" PR template add `&template=Bugfix.md` to this page's URL. -->

<!-- To use "Roadmap" PR template add `&template=Roadmap.md` to this page's URL. -->

<!-- To use "Task" PR template add `&template=Task.md` to this page's URL. -->

<!-- Remove everything above before submitting this PR. -->


<!-- Name this PR as: "Step <step-number>: <step-name>". -->

## Task

Write a simple program which prints out the path to its configuration file. The path should be detected with the following precedence:
1. default path is `/etc/app/app.conf`;
2. if `APP_CONF` env var is specified (and not empty) then use it with higher priority than default;
3. if `--conf` command line argument is specified (error if empty) then use it with the highest priority.

If neither `APP_CONF` env var nor `--conf` command line argument is specified, then no allocation should happen for path detection.






## Solution

One allocation is not possible to avoid since closure cannot lend
