### PR TITLE
task1.8 with quirk

### DIFF
--- a/1_concepts/1_8_thread_safety/src/main.rs
+++ b/1_concepts/1_8_thread_safety/src/main.rs
@@ -1,3 +1,37 @@
+use std::rc::Rc;
+
+struct AssertSend<T: Send>(T);
+
+struct AssertSync<T: Sync>(T);
+
+struct AssertBoth<T: Send + Sync>(T);
+
+
+
 fn main() {
-    println!("Implement me!");
+    struct Data (String);
+    let mut instance = Data("a".into());
+    {
+        AssertSend(&instance);
+        // AssertSend(Rc::new(&instance));
+    };
+    {
+        AssertSync(&mut instance);
+        // AssertSync(Rc::new(&mut instance));
+    };
+    {
+        AssertBoth(&mut instance);
+        AssertBoth(&instance);
+    };
+    {
+        thread_local! {
+            static IDK: u64 = 500;
+        };
+
+        AssertBoth(&IDK) // THIS IS NOT CORRECT:
+        // the address of a thread local is the same but the value can be different, due to 
+        // this is usually implemented paging
+        // we still can send a pointer to this location and access the same location concurently
+        // YET the value behind it is thread loca - this is one of older footguns of rust.
+    };
 }


### PR DESCRIPTION
<!-- To use "Bugfix" PR template add `&template=Bugfix.md` to this page's URL. -->

<!-- To use "Roadmap" PR template add `&template=Roadmap.md` to this page's URL. -->

<!-- To use "Task" PR template add `&template=Task.md` to this page's URL. -->

<!-- Remove everything above before submitting this PR. -->


<!-- Name this PR as: "Step <step-number>: <step-name>". -->


## Task

Implement the following types, which meet conditions:
1. `OnlySync` is `Sync`, but `!Send`.
2. `OnlySend` is `Send`, but `!Sync`.
3. `SyncAndSend` is both `Sync` and `Send`.
4. `NotSyncNotSend` is both `!Sync` and `!Send`.

All inner details of implementation are on your choice.

Play with these types from multiple threads to see how compile time [fearless concurrency][2] works in practice.



## Solution

<!-- Describe how exactly the task is solved by you. Reason about it, if possible. -->
<!-- Give some useful insights about your solution to help understanding it better. -->
