### PR TITLE
Task3 8

### DIFF
--- a/3_ecosystem/3_8_log/Cargo.toml
+++ b/3_ecosystem/3_8_log/Cargo.toml
@@ -7,3 +7,4 @@ publish = false
 [dependencies]
 log="*"
 serde_json="*"
+once_cell="*"

--- a/3_ecosystem/3_8_log/Cargo.toml
+++ b/3_ecosystem/3_8_log/Cargo.toml
@@ -3,3 +3,7 @@ name = "step_3_8"
 version = "0.1.0"
 edition = "2021"
 publish = false
+
+[dependencies]
+log="*"
+serde_json="*"

--- a/3_ecosystem/3_8_log/Cargo.toml
+++ b/3_ecosystem/3_8_log/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-log="*"
-serde_json="*"
-once_cell="*"
+log = { version = "0.4.20" }
+once_cell = "1.19.0"
+serde_json = "1.0.114"

--- a/3_ecosystem/3_8_log/src/main.rs
+++ b/3_ecosystem/3_8_log/src/main.rs
@@ -1,3 +1,138 @@
-fn main() {
-    println!("Implement me!");
+use std::{
+    fmt::format,
+    fs::File,
+    io::Write,
+    mem::zeroed,
+    path::{Path, PathBuf},
+    sync::Mutex,
+    io::BufWriter
+};
+
+struct AppLog;
+
+impl AppLog {
+    fn init() {
+        log::set_logger(&AppLog).expect("cannot set logger");
+    }
+}
+
+impl log::Log for AppLog {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        if record.level() > log::Level::Warn {
+            std::io::stderr()
+                .write_fmt(*record.args())
+                .expect("cannot write to stderr");
+        } else {
+            std::io::stdout()
+                .write_fmt(*record.args())
+                .expect("cannot write to stdout");
+        }
+    }
+
+    fn flush(&self) {
+        let _ = std::io::stdout().flush();
+        let _ = std::io::stderr().flush();
+    }
+}
+
+struct AccessLog(Mutex<(BufWriter<File>, String)>);
+
+impl AccessLog {
+    fn init<P: AsRef<Path>>(to: P) {
+        let file = File::create(to.as_ref()).unwrap();
+        let fname = to.as_ref().file_name().unwrap();
+        // now mutex holds absolutely invalid instance
+        static INSTANCE: AccessLog = Self(Mutex::new((unsafe { zeroed() }, String::new())));
+
+        // we insert a valid instance there
+        INSTANCE
+            .0
+            .lock()
+            .map(|mut g| {
+                g.0 = BufWriter::new(file);
+                g.1 = fname.to_str().expect("cannot name a file").to_owned()
+            })
+            .expect("cannot lock empty mutex");
+
+        log::set_logger(&INSTANCE).expect("cannot set logger");
+    }
+
+    fn write_message<M: AsRef<str>>(&self, lvl: log::Level, msg: M) {
+        self.0
+            .lock()
+            .map(|mut g| {
+                let value = serde_json::json!({
+                    "lvl": lvl.as_str(),
+                    "time": format!("{:?}",std::time::Instant::now()),
+                    "file": g.1,
+                    "msg": msg.as_ref()
+                });
+                writeln!(&mut g.0,"{}", value).expect("cannot write the message");
+            })
+            .expect("death");
+    }
+}
+
+impl log::Log for AccessLog {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        let Some(s) = record.args().as_str() else {
+            panic!("cannot get the data")
+        };
+        self.write_message(record.level(), s)
+    }
+
+    fn flush(&self) {
+        self.0
+            .lock()
+            .map(|mut f| f.0.flush().expect("cannot flush"))
+            .expect("cannot lock");
+    }
+}
+
+fn main() {}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::{AccessLog, AppLog};
+
+    const PATH: &'static str = "./access.log";
+
+    #[test]
+    fn test_fisrt_logger() {
+        AppLog::init();
+
+        log::trace!("trace");
+
+        log::debug!("debug");
+
+        log::info!("info");
+
+        log::warn!("warn");
+
+        log::error!("err");
+    }
+
+    #[test]
+    fn test_second_logger() {
+        AccessLog::init(PATH);
+
+        log::trace!("trace");
+
+        log::debug!("debug");
+
+        log::info!("info");
+
+        log::warn!("warn");
+
+        log::error!("err");
+    }
 }

--- a/3_ecosystem/3_8_log/src/main.rs
+++ b/3_ecosystem/3_8_log/src/main.rs
@@ -1,18 +1,29 @@
 use std::{
-    fmt::format, fs::File, io::{BufWriter, Write}, iter::Once, mem::zeroed, path::{Path, PathBuf}, sync::Mutex
+    fs::File,
+    io::{BufWriter, Write},
+    path::Path,
+    sync::Mutex,
 };
 
 use once_cell::sync::OnceCell;
 
-struct AppLog;
+pub struct AppLog;
 
 impl AppLog {
-    fn init() {
-        log::set_logger(&AppLog).expect("cannot set logger");
+    pub fn init() {
+        static APP_LOG: AppLog = AppLog;
+
+        log::set_logger(&APP_LOG)
+            .map(|()| log::set_max_level(log::LevelFilter::Info))
+            .expect("cannot set logger");
     }
 }
 
- fn make_json_message<M: AsRef<str>>(lvl: log::Level,rec: &log::Record, msg: M) -> serde_json::Value {
+fn make_json_message<M: AsRef<str>>(
+    lvl: log::Level,
+    rec: &log::Record,
+    msg: M,
+) -> serde_json::Value {
     let value = serde_json::json!({
         "lvl": lvl.as_str(),
         "time": format!("{:?}",std::time::Instant::now()),
@@ -20,7 +31,7 @@ impl AppLog {
         "msg": msg.as_ref()
     });
     value
- }
+}
 
 impl log::Log for AppLog {
     fn enabled(&self, _: &log::Metadata) -> bool {
@@ -28,12 +39,15 @@ impl log::Log for AppLog {
     }
 
     fn log(&self, record: &log::Record) {
+        // panic!();
         if record.level() > log::Level::Warn {
-            let msg = make_json_message(record.level(), record, record.args().as_str().unwrap_or(""));
-            write!(std::io::stderr(),"{}",msg.to_string()).unwrap();
+            let msg =
+                make_json_message(record.level(), record, record.args().as_str().unwrap_or(""));
+            let _ = writeln!(std::io::stderr(), "{}", msg);
         } else {
-            let msg = make_json_message(record.level(), record, record.args().as_str().unwrap_or(""));
-            write!(std::io::stdout(),"{}",msg.to_string()).unwrap();
+            let msg =
+                make_json_message(record.level(), record, record.args().as_str().unwrap_or(""));
+            let _ = writeln!(std::io::stdout(), "{}", msg);
         }
     }
 
@@ -43,33 +57,35 @@ impl log::Log for AppLog {
     }
 }
 
-struct AccessLog(OnceCell<(Mutex<BufWriter<File>>, String)>);
+pub struct AccessLog(OnceCell<(Mutex<BufWriter<File>>, String)>);
 
 impl AccessLog {
-    fn init<P: AsRef<Path>>(to: P) {
+    pub fn init<P: AsRef<Path>>(to: P) {
         let file = File::create(to.as_ref()).unwrap();
         let fname = to.as_ref().file_name().unwrap();
-        // now mutex holds absolutely invalid instance which we cannot create
+
         static INSTANCE: AccessLog = AccessLog(OnceCell::new());
 
-        INSTANCE.0.get_or_init(|| (
-            Mutex::new(BufWriter::new(file)),
-            fname.to_str().expect("cannot name a file").to_owned()
-        ));
+        INSTANCE.0.get_or_init(|| {
+            (
+                Mutex::new(BufWriter::new(file)),
+                fname.to_str().expect("cannot name a file").to_owned(),
+            )
+        });
 
-
-        log::set_logger(&INSTANCE).expect("cannot set logger");
+        log::set_logger(&INSTANCE)
+            .map(|()| log::set_max_level(log::LevelFilter::Info))
+            .expect("cannot set logger");
     }
 
-    fn write_message<M: AsRef<str>>(&self,val: serde_json::Value) {
-        self
-            .0
+    fn write_message(&self, val: serde_json::Value) {
+        self.0
             .get()
             .expect("cannot get")
             .0
             .lock()
             .map(|mut g| {
-                writeln!(&mut g,"{}", val.to_string()).expect("cannot write the message");
+                writeln!(&mut g, "{}", val).expect("cannot write the message");
             })
             .expect("death");
     }
@@ -84,12 +100,11 @@ impl log::Log for AccessLog {
         let Some(s) = record.args().as_str() else {
             panic!("cannot get the data")
         };
-        self.write_message::<&str>(make_json_message(record.level(), record, s))
+        self.write_message(make_json_message(record.level(), record, s))
     }
 
     fn flush(&self) {
-        self
-            .0
+        self.0
             .get()
             .expect("cannot get")
             .0
@@ -109,7 +124,7 @@ mod tests {
     const PATH: &'static str = "./access.log";
 
     #[test]
-    fn test_fisrt_logger() {
+    fn test_first_logger() {
         AppLog::init();
 
         log::trace!("trace");

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,9 @@ version = "0.1.0"
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "6ab617d94515e94ae53b8406c628598680aa0c9587474ecbe58188f7b345d66c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +188,7 @@ name = "step_3_8"
 version = "0.1.0"
 dependencies = [
  "log",
+ "once_cell",
  "serde_json",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,73 @@
 version = 3
 
 [[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
+name = "serde"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "step_1"
 version = "0.1.0"
 
@@ -113,6 +180,10 @@ version = "0.1.0"
 [[package]]
 name = "step_3_8"
 version = "0.1.0"
+dependencies = [
+ "log",
+ "serde_json",
+]
 
 [[package]]
 name = "step_3_9"
@@ -133,3 +204,20 @@ version = "0.1.0"
 [[package]]
 name = "step_4_3"
 version = "0.1.0"
+
+[[package]]
+name = "syn"
+version = "2.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Each step must be performed as a separate [PR (pull request)][PR] with an approp
     - [ ] [3.5. Collections and iterators][Step 3.5] (1 day)
     - [ ] [3.6. Serialization and deserialization][Step 3.6] (1 day)
     - [ ] [3.7. Randomness and cryptography][Step 3.7] (1 day)
-    - [ ] [3.8. Logging and tracing][Step 3.8] (1 day)
+    - [x] [3.8. Logging and tracing][Step 3.8] (1 day)
     - [ ] [3.9. Command-line arguments, environment variables and configs][Step 3.9] (1 day)
     - [ ] [3.10. Multithreading and parallelism][Step 3.10] (1 day)
     - [ ] [3.11. Async I/O, futures and actors][Step 3.11] (2 days)


### PR DESCRIPTION
<!-- To use "Bugfix" PR template add `&template=Bugfix.md` to this page's URL. -->

<!-- To use "Roadmap" PR template add `&template=Roadmap.md` to this page's URL. -->

<!-- To use "Task" PR template add `&template=Task.md` to this page's URL. -->

<!-- Remove everything above before submitting this PR. -->


<!-- Name this PR as: "Step <step-number>: <step-name>". -->

Resolves [Step <!-- paste step number -->](<!-- paste step link -->)




## Task

Implement two loggers:
1. Global main `app.log` logger which prints all its logs to `STDOUT`, but `WARN` level (and higher) logs to `STDERR`.
2. Local `access.log` logger which writes all its logs to `access.log` file.

All logs should be structured and logged in a JSON format, and have time field with nanoseconds ([RFC 3339] formatted).

Examples:
```json
{"lvl":"ERROR","file":"app.log","time":"2018-07-30T12:14:14.196483657Z","msg":"Error occurred"}
{"lvl":"INFO","file":"access.log","time":"2018-07-30T12:17:18.721127239Z","msg":"http","method":"POST","path":"/some"}
```


## Solution

<!-- Describe how exactly the task is solved by you. Reason about it, if possible. -->
<!-- Give some useful insights about your solution to help understanding it better. -->
